### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/dpieve/EasyFocus/security/code-scanning/9](https://github.com/dpieve/EasyFocus/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the tasks performed in the workflow. Specifically:
1. Use `contents: read` for read-only access to the repository contents.
2. Use `contents: write` for jobs that upload artifacts, as this requires write access to the repository contents.

This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
