### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on: 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: '9.x'
 
@@ -88,6 +91,8 @@ jobs:
   draft-release:
     needs: [ publish-windows, publish-linux, publish-android ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download windows Artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/dpieve/EasyFocus/security/code-scanning/8](https://github.com/dpieve/EasyFocus/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for all jobs. Additionally, we will add job-specific `permissions` blocks where elevated permissions are necessary. 

1. At the root level, we will set `contents: read` as the default permission since most jobs only need to read repository contents.
2. For the `draft-release` job, we will explicitly grant `contents: write` to allow the creation of a draft release.
3. No other jobs appear to require elevated permissions, so they will inherit the root-level permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
