### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,7 @@
 name: Deploy to GitHub Pages
+permissions:
+  contents: read
+  pages: write
 
 env:
   PROJECT_PATH: src/client/presentation/EasyFocus.Browser/EasyFocus.Browser.csproj


### PR DESCRIPTION
Potential fix for [https://github.com/dpieve/EasyFocus/security/code-scanning/3](https://github.com/dpieve/EasyFocus/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (deploying to GitHub Pages), the `contents: read` and `pages: write` permissions are sufficient. The `contents: read` permission allows the workflow to access the repository's contents, and the `pages: write` permission allows it to deploy to GitHub Pages.

The `permissions` block will be added after the `name` field (line 1) to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
